### PR TITLE
Fix minetest.net link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@
 
 ## Websites
 
-- [Official Download](https://minetest.net)
+- [Official Download](https://www.minetest.net)
 - [Wiki](https://wiki.minetest.net)
 - [Forum](https://forum.minetest.net)
 - [IRC](https://irc.minetest.net)


### PR DESCRIPTION
Actual link without `www.` give:
```
Your connection is not private
Attackers might be trying to steal your information from minetest.net (for example, passwords, messages, or credit cards). [Learn more](chrome-error://chromewebdata/#)
NET::ERR_CERT_AUTHORITY_INVALID
```

while https://www.minetest.net won't